### PR TITLE
Rename to openstack-mitaka-nova

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
   </parent>
   <groupId>io.cloudsoft.jclouds.api</groupId>
   <artifactId>openstack-mitaka-nova</artifactId>
+  <version>1.9.3-cloudsoft.20160831</version>
   <name>jclouds Openstack Mitaka Nova</name>
   <description>OpenStack Nova implementation targeted to Mitaka</description>
   <packaging>bundle</packaging>
@@ -40,24 +41,46 @@
     <test.openstack-mitaka-nova.api-version>2</test.openstack-mitaka-nova.api-version>
     <test.openstack-mitaka-nova.template />
     <jclouds.osgi.export>org.jclouds.openstack.devtest*;version="${project.version}"</jclouds.osgi.export>
-    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
+    <jclouds.osgi.import>org.jclouds*,*</jclouds.osgi.import>
+    <jclouds.cloudsoft.groupId>io.cloudsoft.jclouds</jclouds.cloudsoft.groupId>
+    <jclouds.cloudsoft.version>1.9.3-cloudsoft.20160725</jclouds.cloudsoft.version>
   </properties>
 
   <dependencies>
+    <!-- 
+        Rely on openstack-nova pulling in the right version of jclouds-core and jclouds-compute.
+        Exclude it from all other sources. 
+    -->
     <dependency>
-      <groupId>${jclouds.groupId}.api</groupId>
+      <groupId>${jclouds.cloudsoft.groupId}.api</groupId>
       <artifactId>openstack-nova</artifactId>
-      <version>${project.parent.version}</version>
+      <version>${jclouds.cloudsoft.version}</version>
     </dependency>
     <dependency>
       <groupId>${jclouds.groupId}.driver</groupId>
       <artifactId>jclouds-bouncycastle</artifactId>
       <version>${project.parent.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.jclouds</groupId>
+          <artifactId>jclouds-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>${jclouds.groupId}.driver</groupId>
       <artifactId>jclouds-sshj</artifactId>
       <version>${project.parent.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.jclouds</groupId>
+          <artifactId>jclouds-compute</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.jclouds</groupId>
+          <artifactId>jclouds-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- for the extension namespaces -->
@@ -66,30 +89,30 @@
       <artifactId>guice-multibindings</artifactId>
     </dependency>
     <dependency>
-      <groupId>${jclouds.groupId}</groupId>
+      <groupId>${jclouds.cloudsoft.groupId}</groupId>
       <artifactId>jclouds-core</artifactId>
-      <version>${project.parent.version}</version>
+      <version>${jclouds.cloudsoft.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${jclouds.groupId}</groupId>
+      <groupId>${jclouds.cloudsoft.groupId}</groupId>
       <artifactId>jclouds-compute</artifactId>
-      <version>${project.parent.version}</version>
+      <version>${jclouds.cloudsoft.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${jclouds.groupId}.api</groupId>
+      <groupId>${jclouds.cloudsoft.groupId}.api</groupId>
       <artifactId>openstack-nova</artifactId>
-      <version>${project.parent.version}</version>
+      <version>${jclouds.cloudsoft.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${jclouds.groupId}.api</groupId>
+      <groupId>${jclouds.cloudsoft.groupId}.api</groupId>
       <artifactId>openstack-keystone</artifactId>
-      <version>${project.parent.version}</version>
+      <version>${jclouds.cloudsoft.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
@@ -98,6 +121,12 @@
       <artifactId>jclouds-slf4j</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.jclouds</groupId>
+          <artifactId>jclouds-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,22 +24,22 @@
     <artifactId>jclouds-project</artifactId>
     <version>1.9.2</version>
   </parent>
-  <groupId>io.cloudsoft.jclouds.provider</groupId>
-  <artifactId>openstack-devtest-compute</artifactId>
-  <name>jclouds Openstack DevTest provider</name>
-  <description>OpenStack Nova implementation targeted to DevTest</description>
+  <groupId>io.cloudsoft.jclouds.api</groupId>
+  <artifactId>openstack-mitaka-nova</artifactId>
+  <name>jclouds Openstack Mitaka Nova</name>
+  <description>OpenStack Nova implementation targeted to Mitaka</description>
   <packaging>bundle</packaging>
 
   <properties>
     <jclouds.groupId>org.apache.jclouds</jclouds.groupId>
-    <test.openstack-devtest-compute.endpoint>https://127.0.0.1/v2.0/</test.openstack-devtest-compute.endpoint>
-    <test.openstack-devtest-compute.api-version>2</test.openstack-devtest-compute.api-version>
-    <test.openstack-devtest-compute.build-version />
-    <test.openstack-devtest-compute.identity>FIXME_IDENTITY</test.openstack-devtest-compute.identity>
-    <test.openstack-devtest-compute.credential>FIXME_CREDENTIAL</test.openstack-devtest-compute.credential>
-    <test.openstack-devtest-compute.api-version>2</test.openstack-devtest-compute.api-version>
-    <test.openstack-devtest-compute.template />
-    <jclouds.osgi.export>org.jclouds.devtest.openstack*;version="${project.version}"</jclouds.osgi.export>
+    <test.openstack-mitaka-nova.endpoint>https://127.0.0.1/v2.0/</test.openstack-mitaka-nova.endpoint>
+    <test.openstack-mitaka-nova.api-version>2</test.openstack-mitaka-nova.api-version>
+    <test.openstack-mitaka-nova.build-version />
+    <test.openstack-mitaka-nova.identity>FIXME_IDENTITY</test.openstack-mitaka-nova.identity>
+    <test.openstack-mitaka-nova.credential>FIXME_CREDENTIAL</test.openstack-mitaka-nova.credential>
+    <test.openstack-mitaka-nova.api-version>2</test.openstack-mitaka-nova.api-version>
+    <test.openstack-mitaka-nova.template />
+    <jclouds.osgi.export>org.jclouds.openstack.devtest*;version="${project.version}"</jclouds.osgi.export>
     <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
   </properties>
 
@@ -216,12 +216,12 @@
                 <configuration>
                   <threadCount>1</threadCount>
                   <systemPropertyVariables>
-                    <test.openstack-devtest-compute.endpoint>${test.openstack-devtest-compute.endpoint}</test.openstack-devtest-compute.endpoint>
-                    <test.openstack-devtest-compute.api-version>${test.openstack-devtest-compute.api-version}</test.openstack-devtest-compute.api-version>
-                    <test.openstack-devtest-compute.build-version>${test.openstack-devtest-compute.build-version}</test.openstack-devtest-compute.build-version>
-                    <test.openstack-devtest-compute.identity>${test.openstack-devtest-compute.identity}</test.openstack-devtest-compute.identity>
-                    <test.openstack-devtest-compute.credential>${test.openstack-devtest-compute.credential}</test.openstack-devtest-compute.credential>
-                    <test.openstack-devtest-compute.template>${test.openstack-devtest-compute.template}</test.openstack-devtest-compute.template>
+                    <test.openstack-mitaka-nova.endpoint>${test.openstack-mitaka-nova.endpoint}</test.openstack-mitaka-nova.endpoint>
+                    <test.openstack-mitaka-nova.api-version>${test.openstack-mitaka-nova.api-version}</test.openstack-mitaka-nova.api-version>
+                    <test.openstack-mitaka-nova.build-version>${test.openstack-mitaka-nova.build-version}</test.openstack-mitaka-nova.build-version>
+                    <test.openstack-mitaka-nova.identity>${test.openstack-mitaka-nova.identity}</test.openstack-mitaka-nova.identity>
+                    <test.openstack-mitaka-nova.credential>${test.openstack-mitaka-nova.credential}</test.openstack-mitaka-nova.credential>
+                    <test.openstack-mitaka-nova.template>${test.openstack-mitaka-nova.template}</test.openstack-mitaka-nova.template>
                   </systemPropertyVariables>
                 </configuration>
               </execution>

--- a/src/main/java/org/jclouds/openstack/devtest/OpenstackDevTestProviderMetadata.java
+++ b/src/main/java/org/jclouds/openstack/devtest/OpenstackDevTestProviderMetadata.java
@@ -78,8 +78,8 @@ public class OpenstackDevTestProviderMetadata extends BaseProviderMetadata {
    public static class Builder extends BaseProviderMetadata.Builder {
 
       protected Builder() {
-         id("openstack-devtest-compute")
-                 .name("Openstack DevTest Compute Services")
+         id("openstack-mitaka-nova")
+                 .name("OpenStack Mitaka Nova")
                  .apiMetadata(new NovaApiMetadata().toBuilder()
                          .identityName("${tenantName}:${accessKey}")
                          .credentialName("${secretKey}")
@@ -96,9 +96,9 @@ public class OpenstackDevTestProviderMetadata extends BaseProviderMetadata {
                                  .add(NovaComputeServiceContextModule.class)
                                  .build())
                          .build())
-                 .homepage(URI.create("https://wiki.openstack.org/wiki/Tuskar/Devtest"))
+                 .homepage(URI.create("https://www.openstack.org/software/mitaka/"))
                  .console(URI.create("https://127.0.0.1/horizon"))
-                 .linkedServices("openstack-devtest-compute")
+                 .linkedServices("openstack-mitaka-nova")
                  .endpoint("https://127.0.0.1/identity/v2.0/")
                  .defaultProperties(OpenstackDevTestProviderMetadata.defaultProperties());
       }


### PR DESCRIPTION
This is for openstack-mitaka-nova, rather than just for devtest.

I confirmed that I could deploy to OpenStack (BluBox) using both the original openstack-nova and with openstack-mitaka-nova. However, I didn't test deploying to an actual Mitaka OpenStack environment!
